### PR TITLE
chore: set the .github\CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://help.github.com/articles/about-codeowners/
+
+* @bitpredator


### PR DESCRIPTION
Set the CODEOWNERS file to automatically assign review of pull requests to the code owner, and also make it clear to the community who owns it.