### PR TITLE
Fix XSS vulnerability by replacing innerHTML with textContent

### DIFF
--- a/server-data/resources/[core]/qb-core/html/js/drawtext.js
+++ b/server-data/resources/[core]/qb-core/html/js/drawtext.js
@@ -22,7 +22,9 @@ const drawText = async (textData) => {
             break;
     }
 
-    text.innerHTML = textData.text;
+    // Protezione XSS
+    text.textContent = textData.text;
+
     document.getElementById("drawtext-container").style.display = "block";
     await sleep(100);
     addClass(text, "show");
@@ -62,7 +64,9 @@ const changeText = async (textData) => {
             direction = "left";
             break;
     }
-    text.innerHTML = textData.text;
+
+    // Protezione XSS
+    text.textContent = textData.text;
 
     await sleep(100);
     text.classList.add("show");


### PR DESCRIPTION
### Summary

This pull request addresses a potential client-side XSS vulnerability in the `drawText` and `changeText` functions by replacing the unsafe use of `innerHTML` with `textContent`.

### Changes

- Replaced `element.innerHTML = textData.text` with `element.textContent = textData.text` to prevent HTML/JS injection.
- No impact on functionality; the displayed text remains the same.
- Improves security for UI components receiving external input (e.g., via `postMessage` events).

### Why this is important

Using `innerHTML` with untrusted or dynamic input can lead to cross-site scripting (XSS), which could allow attackers to execute arbitrary JavaScript in the browser. Switching to `textContent` ensures the input is treated as plain text, effectively neutralizing this threat.

### Related

No issue opened, but security best practice.

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

Fixes #[issue_no]
### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Does your submission pass tests?

**Please describe the changes this PR makes and why it should be merged:**


<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):